### PR TITLE
Update composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,9 +10,9 @@
     "type": "flarum-extension",
     "license": "MIT",
     "require": {
-        "flarum/core": "^1.2",
+        "flarum/core": "*",
         "antoinefr/flarum-ext-money": "*",
-        "fof/polls": "^1.3"
+        "fof/polls": "*"
     },
     "authors": [
         {


### PR DESCRIPTION
The original composer.json will limit update of fof/polls. I tried to update to fof/poll:"^2.2" but failed with a notice that this extension require 1.3, or 1.4 version of fof/polls.